### PR TITLE
Update brotli API, add window size, add timeout to resource download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+brotli-test
+brotli-test.o
+resources/
+results/
+temp/
+

--- a/brotli-test.cc
+++ b/brotli-test.cc
@@ -1,48 +1,44 @@
 #include <stdlib.h>
 #include <stdio.h>
-#include <brotli/enc/encode.h>
+#include <brotli/encode.h>
 #include <zlib.h>
 #include <time.h>
 #include <iostream>
 #include <sstream>
 #include <iomanip>
 
-size_t file_size(FILE * file) {
+size_t file_size(FILE* file) {
   fseek(file, 0, SEEK_END);
   size_t size = ftell(file);
   fseek(file, 0, SEEK_SET);
   return size;
 }
 
-FILE * open_file(const char * filename, const char * mode) {
-  FILE * file = fopen(filename, mode);
+FILE* open_file(const char* filename, const char* mode) {
+  FILE* file = fopen(filename, mode);
   if (file == NULL) {
     perror("fopen failed");
   }
   return file;
 }
 
-void read_data(FILE * file, char ** data, size_t * size) {
+void read_data(FILE* file, unsigned char** data, size_t* size) {
   *size = file_size(file);
-  *data = (char *) malloc(*size);
+  *data = (unsigned char*) malloc(*size);
   if (0 == fread(*data, 1, *size, file)) {
     throw "Failed to read from file";
   }
   return;
 }
 
-size_t brotli_compress(int level, const char * input_data, size_t input_size, char * output_data, size_t output_buffer_size) {
-  brotli::BrotliParams params;
-  params.quality = level;
-  brotli::BrotliMemIn in(input_data, input_size);
-  brotli::BrotliMemOut out(output_data, output_buffer_size);
-  if (!brotli::BrotliCompress(params, &in, &out)) {
+size_t brotli_compress(int level, int window, const unsigned char* input_data, size_t input_size, unsigned char* output_data, size_t output_buffer_size) {
+  if (!BrotliEncoderCompress(level, window, BROTLI_MODE_GENERIC, input_size, input_data, &output_buffer_size, output_data)) {
     throw "Failure in BrotliCompress";
   }
-  return out.position();
+  return output_buffer_size;
 }
 
-size_t zlib_compress(int level, const char * input_data, size_t input_size, char * output_data, size_t output_buffer_size) {
+size_t zlib_compress(int level, int window, const unsigned char* input_data, size_t input_size, unsigned char* output_data, size_t output_buffer_size) {
   z_stream strm;
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
@@ -51,9 +47,9 @@ size_t zlib_compress(int level, const char * input_data, size_t input_size, char
     throw "Failure in deflateInit";
   }
   strm.avail_in = input_size;
-  strm.next_in = (unsigned char *) input_data;
+  strm.next_in = (unsigned char*) input_data;
   strm.avail_out = output_buffer_size;
-  strm.next_out = (unsigned char *) output_data;
+  strm.next_out = output_data;
   if (Z_STREAM_ERROR == deflate(&strm, Z_FINISH)) {
     throw "Failure in deflate";
   }
@@ -65,14 +61,14 @@ size_t zlib_compress(int level, const char * input_data, size_t input_size, char
   return output_size;
 }
 
-typedef size_t (*CompressionFunc)(int, const char *, size_t, char *, size_t);
+typedef size_t (*CompressionFunc)(int, int, const unsigned char*, size_t, unsigned char*, size_t);
 
-void measure_compress(const char * name, int level, const char * input_data, size_t input_size, char * output_data, size_t output_buffer_size, CompressionFunc compress, std::ostream & results) {
+void measure_compress(const char* name, int level, int window, const unsigned char* input_data, size_t input_size, unsigned char* output_data, size_t output_buffer_size, CompressionFunc compress, std::ostream & results) {
   int repetitions = 100;
   size_t total_output_size = 0;
   clock_t start = clock();
   for (int i = 0 ; i < repetitions ; i++) {
-    total_output_size += compress(level, input_data, input_size, output_data, output_buffer_size);
+    total_output_size += compress(level, window, input_data, input_size, output_data, output_buffer_size);
   }
   clock_t end = clock();
   float elapsed_time = (float) (end - start) / CLOCKS_PER_SEC;
@@ -83,30 +79,43 @@ void measure_compress(const char * name, int level, const char * input_data, siz
   results << name << level << "_speed\":" << std::setprecision(3) << compression_speed;
 }
 
-int main (int argc, char ** argv) {
+int min_window_larger_than_file(int fileSize, int max) {
+    int window = 1;
+    while (fileSize > 0 && window < max) {
+        fileSize /= 2;
+        ++window;
+    }
+    return window;
+}
+
+int main (int argc, char** argv) {
+  int DEFAULT_WINDOW = 24;
   try {
-    FILE * infile = open_file(argv[1], "rb");
+    FILE* infile = open_file(argv[1], "rb");
     if (infile == NULL) {
       exit(1);
     }
-    char * input_data = NULL;
+    unsigned char* input_data = NULL;
     size_t input_size = 0;
     read_data(infile, &input_data, &input_size);
     fclose(infile);
 
     size_t output_buffer_size = input_size * 2;
-    char * output_data = (char *) malloc(output_buffer_size);
+    unsigned char* output_data = (unsigned char*) malloc(output_buffer_size);
 
     std::ostringstream results;
+
+    int window = min_window_larger_than_file(input_size, DEFAULT_WINDOW);
+
     results << "{\"valid\":true, \"original_size\":" << input_size << ",\n";
     for (int level = 1 ; level <= 11 ; level ++) {
-      measure_compress("brotli", level, input_data, input_size, output_data, output_buffer_size, brotli_compress, results);
+      measure_compress("brotli", level, window, input_data, input_size, output_data, output_buffer_size, brotli_compress, results);
       results << ",\n";
     }
-    measure_compress("zlib", 6, input_data, input_size, output_data, output_buffer_size, zlib_compress, results);
+    measure_compress("zlib", 6, window, input_data, input_size, output_data, output_buffer_size, zlib_compress, results);
     results << "}\n";
     std::cout << results.str();
-  } catch (const char * message) {
+  } catch (const char* message) {
     std::cout << "{\"valid\":false, \"message\":\"" << message << "\"}\n";
   }
   return 0;

--- a/download_resources.sh
+++ b/download_resources.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-wget -U "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Safari/537.36" -e robots=off --no-parent --accept htm,html,js,css,xml,json --no-check-certificate -nd -E -H -p -P resources/$1 $1
+wget -U "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Safari/537.36" -e robots=off --no-parent --accept htm,html,js,css,xml,json --no-check-certificate -T10 --tries=2 -nd -E -H -p -P resources/$1 $1


### PR DESCRIPTION
This change updates the brotli API (the previous one didn't really build with latest brotli).
It also adds a window size for extra tinkering and limits the resource download timeout, to make sure it doesn't get stuck.